### PR TITLE
Fixed transcribe to SRT

### DIFF
--- a/pyannote_whisper/cli/transcribe.py
+++ b/pyannote_whisper/cli/transcribe.py
@@ -115,7 +115,7 @@ def cli():
             with open(os.path.join(output_dir, audio_basename + ".vtt"), "w", encoding="utf-8") as file:
                 WriteVTT(output_dir).write_result(result, file=file)
 
-        elif output_format == "VTT":
+        elif output_format == "SRT":
             # save SRT
            with open(os.path.join(output_dir, audio_basename + ".srt"), "w", encoding="utf-8") as file:
                 WriteSRT(output_dir).write_result(result, file=file)


### PR DESCRIPTION
Fix incorrect exporting to SRT.

Tested with the provided data:
` python -m pyannote_whisper.cli.transcribe data/afjiv.wav --model tiny --diarization True --output_format SRT`